### PR TITLE
Remove unnecessary dedent

### DIFF
--- a/src/dj_beat_drop/new.py
+++ b/src/dj_beat_drop/new.py
@@ -3,7 +3,6 @@ import re
 import shutil
 import urllib.parse
 from pathlib import Path
-from textwrap import dedent
 
 from InquirerPy import inquirer
 from packaging.version import Version
@@ -42,7 +41,7 @@ def replace_sqlite_config(content: str, django_version: str) -> str:
     rtn_val = content
     rtn_val = re.sub(
         r"^DATABASES\s*=\s*\{.+?\}\n\}",
-        dedent(
+        (
             "DATABASES = {\n"
             "    'default': {\n"
             "        'ENGINE': 'django.db.backends.sqlite3',\n"


### PR DESCRIPTION
@epicserve thanks for merging https://github.com/epicserve/dj-beat-drop/pull/9. I like your solution with using tuple instead of the `"{% 5.1 %}"` prefix, much cleaner!

I'm opening a small cleanup PR because I noticed a `dedent` call that's not doing anything anymore.

